### PR TITLE
Add long description and pep8ify setup py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,19 +6,19 @@
 from distutils.core import setup
 
 setup(
-        name = 'on_the_fly',
-        packages = ['on_the_fly',],
-        version = "0.02rc3",
-        description = """on_the_fly: out-of-core learning for PySpark and Python iterators'
-
+        name='on_the_fly',
+        packages=['on_the_fly', ],
+        version="0.02rc4",
+        description='on_the_fly: out-of-core learning for PySpark and Python iterators.',
+        long_description="""
         on_the_fly is a machine learning toolkit designed to efficiently perform
         online feature extraction and learning on RDD and Python iterators.
         """,
-        author = 'Peng Yu',
-        author_email = 'yupbank@gmail.com',
-        url = 'https://github.com/yupbank/on_the_fly',
-        download_url = 'https://github.com/yupbank/on_the_fly/archive/0.02rc3.tar.gz',
-        keywords = ['on the fly', 'machine learning', 'sklearn', 'online'],
-        classifiers = [],
-        install_requires = open('requirements.txt').read().split()
+        author='Peng Yu',
+        author_email='yupbank@gmail.com',
+        url='https://github.com/yupbank/on_the_fly',
+        download_url='https://github.com/yupbank/on_the_fly/archive/0.02rc4.tar.gz',
+        keywords=['on the fly', 'machine learning', 'sklearn', 'online'],
+        classifiers=[],
+        install_requires=open('requirements.txt').read().split()
         )


### PR DESCRIPTION
- Moves out the description as a long description

Currently:
![image](https://cloud.githubusercontent.com/assets/270844/23389906/e59dbd32-fd38-11e6-8745-ca19bd114088.png)

This makes it look more like Numpy:
![image](https://cloud.githubusercontent.com/assets/270844/23389913/eafe8fe0-fd38-11e6-9daa-1a6d656a136f.png)

cc @yupbank 